### PR TITLE
Update plugin versions for compatibility

### DIFF
--- a/lua/plugins/git-integration.lua
+++ b/lua/plugins/git-integration.lua
@@ -1,8 +1,9 @@
 return {
 	{ "tpope/vim-fugitive" },
-	{
-		"lewis6991/gitsigns.nvim",
-		opts = {
+        {
+                "lewis6991/gitsigns.nvim",
+                version = "v1.0.0",
+                opts = {
 			signs = {
 				add = { text = "┃" },
 				change = { text = "┃" },

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -5,14 +5,15 @@ return {
 			require("mason").setup()
 		end,
 	},
-	{
-		"williamboman/mason-lspconfig.nvim",
-		config = function()
-			require("mason-lspconfig").setup({
-				ensure_installed = { "lua_ls", "pyright" },
-			})
-		end,
-	},
+        {
+                "williamboman/mason-lspconfig.nvim",
+                version = "v1.x",
+                config = function()
+                        require("mason-lspconfig").setup({
+                                ensure_installed = { "lua_ls", "pyright" },
+                        })
+                end,
+        },
 	{
 		"neovim/nvim-lspconfig",
 		config = function()

--- a/lua/plugins/yazi.lua
+++ b/lua/plugins/yazi.lua
@@ -1,5 +1,6 @@
 return {
   "mikavilpas/yazi.nvim",
+  version = "v9.2.1",
   event = "VeryLazy",
   dependencies = {
     "folke/snacks.nvim",


### PR DESCRIPTION
## Summary
- pin `mason-lspconfig.nvim` to `v1.x` so `vim.lsp.enable` isn't required
- pin `gitsigns.nvim` to release `v1.0.0`
- update `yazi.nvim` to version `v9.2.1`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851101e661c832cb519c1c895abf85b