### PR TITLE
stop auto installing Mason tools

### DIFF
--- a/lua/core/mason.lua
+++ b/lua/core/mason.lua
@@ -32,14 +32,14 @@ return {
 				end, 100)
 			end)
 
-			-- Auto-install servers on startup if they're not installed
-			vim.defer_fn(function()
-				for _, tool in ipairs(opts.ensure_installed) do
-					if not mr.is_installed(tool) then
-						vim.cmd("MasonInstall " .. tool)
-					end
-				end
-			end, 100)
+                        -- Auto-install servers removed; install tools manually or via CI
+                        -- vim.defer_fn(function()
+                        --         for _, tool in ipairs(opts.ensure_installed) do
+                        --                 if not mr.is_installed(tool) then
+                        --                         vim.cmd("MasonInstall " .. tool)
+                        --                 end
+                        --         end
+                        -- end, 100)
 		end,
 	},
 	{


### PR DESCRIPTION
## Summary
- disable auto MasonInstall and rely on manual or CI provisioning

## Testing
- `nvim --headless -u init.lua +q` *(fails: module 'core.options' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a355f583fc832ca164af733a655b37