### PR TITLE
refactor: use keymap.set for neovide clipboard mappings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,8 +18,8 @@ if vim.g.neovide then
 	vim.g.neovide_window_floating_opacity = 0.8
 
 	-- Allow clipboard copy paste in neovim
-	vim.api.nvim_set_keymap('', '<D-v>', '+p<CR>', { noremap = true, silent = true})
-	vim.api.nvim_set_keymap('!', '<D-v>', '<C-R>+', { noremap = true, silent = true})
-	vim.api.nvim_set_keymap('t', '<D-v>', '<C-R>+', { noremap = true, silent = true})
-	vim.api.nvim_set_keymap('v', '<D-v>', '<C-R>+', { noremap = true, silent = true})
+        vim.keymap.set('', '<D-v>', '+p<CR>', { noremap = true, silent = true })
+        vim.keymap.set('!', '<D-v>', '<C-R>+', { noremap = true, silent = true })
+        vim.keymap.set('t', '<D-v>', '<C-R>+', { noremap = true, silent = true })
+        vim.keymap.set('v', '<D-v>', '<C-R>+', { noremap = true, silent = true })
 end


### PR DESCRIPTION
## Summary
- use `vim.keymap.set` instead of deprecated `nvim_set_keymap`

## Testing
- `luacheck init.lua` *(warnings: accessing undefined variable vim)*

------
https://chatgpt.com/codex/tasks/task_e_68a354305b3c832c88528fb245d8dcf9