### PR TITLE
refactor: unify feature toggles

### DIFF
--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -1,222 +1,136 @@
 local M = {}
 
--- Simple global diagnostics state with persistence
-local diagnostics_file = vim.fn.stdpath("data") .. "/diagnostics_enabled"
-
--- Load saved state or default to true
-local function load_diagnostics_state()
-	local file = io.open(diagnostics_file, "r")
-	if file then
-		local content = file:read("*a")
-		file:close()
-		return content:match("1") ~= nil
-	end
-	return true -- Default enabled
-end
-
--- Save diagnostics state
-local function save_diagnostics_state(enabled)
-	local file = io.open(diagnostics_file, "w")
-	if file then
-		file:write(enabled and "1" or "0")
-		file:close()
-	end
-end
-
--- Global diagnostics state
-_G.DIAGNOSTICS_ENABLED = load_diagnostics_state()
-
--- Simple diagnostics toggle function
-function M.toggle_diagnostics()
-	_G.DIAGNOSTICS_ENABLED = not _G.DIAGNOSTICS_ENABLED
-	save_diagnostics_state(_G.DIAGNOSTICS_ENABLED)
-	
-	-- Apply the toggle immediately
-	if _G.DIAGNOSTICS_ENABLED then
-		vim.diagnostic.config({
-			virtual_text = {
-				enabled = true,
-				source = "always",
-				prefix = "●",
-			},
-			signs = true,
-			underline = true,
-			update_in_insert = false,
-			severity_sort = true,
-		})
-		vim.diagnostic.show()
-	else
-		vim.diagnostic.config({
-			virtual_text = false,
-			signs = false,
-			underline = false,
-			update_in_insert = false,
-		})
-		vim.diagnostic.hide()
-	end
-	
-	return _G.DIAGNOSTICS_ENABLED
-end
-
--- Initialize diagnostics on startup
-vim.defer_fn(function()
-	if _G.DIAGNOSTICS_ENABLED then
-		vim.diagnostic.config({
-			virtual_text = {
-				enabled = true,
-				source = "always",
-				prefix = "●",
-			},
-			signs = true,
-			underline = true,
-			update_in_insert = false,
-			severity_sort = true,
-		})
-		vim.diagnostic.show()
-	else
-		vim.diagnostic.config({
-			virtual_text = false,
-			signs = false,
-			underline = false,
-			update_in_insert = false,
-		})
-		vim.diagnostic.hide()
-	end
-end, 100)
-
--- Function to create a toggleable state with persistence (for other toggles)
+-- Function to create a toggleable state with persistence
 function M.create_toggle(name, default_state)
-	local file_path = vim.fn.stdpath("data") .. "/" .. name .. "_state"
+  local file_path = vim.fn.stdpath("data") .. "/" .. name .. "_state"
 
-	local state = default_state
+  local state = default_state
 
-	-- Load the saved state
-	local file = io.open(file_path, "r")
-	if file then
-		local content = file:read("*a")
-		file:close()
-		state = (content == "1")
-	end
+  -- Load the saved state
+  local file = io.open(file_path, "r")
+  if file then
+    local content = file:read("*a")
+    file:close()
+    state = (content == "1")
+  end
 
-	-- Function to save the current state
-	local function save()
-		local f = io.open(file_path, "w")
-		if f then
-			f:write(state and "1" or "0")
-			f:close()
-		end
-	end
+  -- Function to save the current state
+  local function save()
+    local f = io.open(file_path, "w")
+    if f then
+      f:write(state and "1" or "0")
+      f:close()
+    end
+  end
 
-	-- Return a table with the state and toggle function
-	return {
-		is_enabled = function() return state end,
-		toggle = function()
-			state = not state
-			save()
-			return state
-		end,
-		set_initial_state = function(enable_cmd, disable_cmd)
-			vim.defer_fn(function()
-				if state then
-					vim.cmd(enable_cmd)
-				else
-					vim.cmd(disable_cmd)
-				end
-			end, 100)
-		end,
-	}
+  -- Return a table with the state and toggle function
+  return {
+    is_enabled = function() return state end,
+    toggle = function()
+      state = not state
+      save()
+      return state
+    end,
+    set_initial_state = function(enable_cmd, disable_cmd)
+      vim.defer_fn(function()
+        if state then
+          vim.cmd(enable_cmd)
+        else
+          vim.cmd(disable_cmd)
+        end
+      end, 100)
+    end,
+  }
 end
 
--- Simple global completion popup state with persistence
-local completion_file = vim.fn.stdpath("data") .. "/completion_enabled"
+-- Diagnostics ---------------------------------------------------------------
+local diagnostics = M.create_toggle("diagnostics", true)
+_G.DIAGNOSTICS_ENABLED = diagnostics.is_enabled()
 
--- Load saved state or default to true
-local function load_completion_state()
-	local file = io.open(completion_file, "r")
-	if file then
-		local content = file:read("*a")
-		file:close()
-		return content:match("1") ~= nil
-	end
-	return true -- Default enabled
+local function enable_diagnostics()
+  vim.diagnostic.config({
+    virtual_text = {
+      enabled = true,
+      source = "always",
+      prefix = "●",
+    },
+    signs = true,
+    underline = true,
+    update_in_insert = false,
+    severity_sort = true,
+  })
+  vim.diagnostic.show()
 end
 
--- Save completion state
-local function save_completion_state(enabled)
-	local file = io.open(completion_file, "w")
-	if file then
-		file:write(enabled and "1" or "0")
-		file:close()
-	end
+local function disable_diagnostics()
+  vim.diagnostic.config({
+    virtual_text = false,
+    signs = false,
+    underline = false,
+    update_in_insert = false,
+  })
+  vim.diagnostic.hide()
 end
 
--- Global completion state
-_G.COMPLETION_ENABLED = load_completion_state()
+function M.toggle_diagnostics()
+  local enabled = diagnostics.toggle()
+  _G.DIAGNOSTICS_ENABLED = enabled
+  if enabled then
+    enable_diagnostics()
+  else
+    disable_diagnostics()
+  end
+  return enabled
+end
 
--- Simple completion toggle function
+M.enable_diagnostics = enable_diagnostics
+M.disable_diagnostics = disable_diagnostics
+
+diagnostics.set_initial_state(
+  "lua require('core.state').enable_diagnostics()",
+  "lua require('core.state').disable_diagnostics()"
+)
+
+-- Completion ---------------------------------------------------------------
+local completion = M.create_toggle("completion", true)
+_G.COMPLETION_ENABLED = completion.is_enabled()
+
 function M.toggle_completion()
-	_G.COMPLETION_ENABLED = not _G.COMPLETION_ENABLED
-	save_completion_state(_G.COMPLETION_ENABLED)
-	
-	-- Close any open completion menu if disabling
-	if not _G.COMPLETION_ENABLED then
-		local ok, cmp = pcall(require, "cmp")
-		if ok and cmp.visible() then
-			cmp.close()
-		end
-	end
-	
-	return _G.COMPLETION_ENABLED
+  local enabled = completion.toggle()
+  _G.COMPLETION_ENABLED = enabled
+  if not enabled then
+    local ok, cmp = pcall(require, "cmp")
+    if ok and cmp.visible() then
+      cmp.close()
+    end
+  end
+  return enabled
 end
 
--- Simple global copilot state with persistence
-local copilot_file = vim.fn.stdpath("data") .. "/copilot_enabled"
+-- Copilot ------------------------------------------------------------------
+local copilot = M.create_toggle("copilot", true)
+_G.COPILOT_ENABLED = copilot.is_enabled()
 
--- Load saved state or default to true
-local function load_copilot_state()
-	local file = io.open(copilot_file, "r")
-	if file then
-		local content = file:read("*a")
-		file:close()
-		return content:match("1") ~= nil
-	end
-	return true -- Default enabled
+local function enable_copilot()
+  vim.cmd("Copilot enable")
 end
 
--- Save copilot state
-local function save_copilot_state(enabled)
-	local file = io.open(copilot_file, "w")
-	if file then
-		file:write(enabled and "1" or "0")
-		file:close()
-	end
+local function disable_copilot()
+  vim.cmd("Copilot disable")
 end
 
--- Global copilot state
-_G.COPILOT_ENABLED = load_copilot_state()
-
--- Simple copilot toggle function
 function M.toggle_copilot()
-	_G.COPILOT_ENABLED = not _G.COPILOT_ENABLED
-	save_copilot_state(_G.COPILOT_ENABLED)
-	
-	-- Apply the toggle immediately
-	if _G.COPILOT_ENABLED then
-		vim.cmd("Copilot enable")
-	else
-		vim.cmd("Copilot disable")
-	end
-	
-	return _G.COPILOT_ENABLED
+  local enabled = copilot.toggle()
+  _G.COPILOT_ENABLED = enabled
+  if enabled then
+    enable_copilot()
+  else
+    disable_copilot()
+  end
+  return enabled
 end
 
--- Initialize copilot on startup
-vim.defer_fn(function()
-	if _G.COPILOT_ENABLED then
-		vim.cmd("Copilot enable")
-	else
-		vim.cmd("Copilot disable")
-	end
-end, 300)
+copilot.set_initial_state("Copilot enable", "Copilot disable")
 
 return M
+


### PR DESCRIPTION
## Summary
- use `create_toggle` for diagnostics, completion, and copilot
- expose toggle functions via returned toggle helpers
- drop bespoke state save/load helpers

## Testing
- `luac -p lua/core/state.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a3542a41e8832c9f1e35cbc16f5cf3