### PR TITLE
refactor(mason): install via registry

### DIFF
--- a/lua/core/mason.lua
+++ b/lua/core/mason.lua
@@ -12,11 +12,8 @@ return {
 				"lua-language-server", -- lua_ls
 
 				-- Formatters
-				"stylua",
-				"ruff",
-
-				-- Linters
-				"ruff", -- also used for linting
+                                "stylua",
+                                "ruff", -- also used for linting
 			},
 		},
 		config = function(_, opts)
@@ -33,13 +30,16 @@ return {
 			end)
 
 			-- Auto-install servers on startup if they're not installed
-			vim.defer_fn(function()
-				for _, tool in ipairs(opts.ensure_installed) do
-					if not mr.is_installed(tool) then
-						vim.cmd("MasonInstall " .. tool)
-					end
-				end
-			end, 100)
+                        vim.defer_fn(function()
+                                mr.refresh(function()
+                                        for _, tool in ipairs(opts.ensure_installed) do
+                                                local pkg = mr.get_package(tool)
+                                                if not pkg:is_installed() then
+                                                        pkg:install()
+                                                end
+                                        end
+                                end)
+                        end, 100)
 		end,
 	},
 	{


### PR DESCRIPTION
## Summary
- remove duplicate `ruff` entry from Mason ensure list
- install Mason tools via registry API instead of shell commands

## Testing
- `nvim --headless -n -u NONE --cmd "set rtp+=/root/.local/share/nvim/lazy/mason.nvim" --cmd "lua package.path = package.path .. ';./lua/?.lua;./lua/?/init.lua'" --cmd "lua require('mason').setup{}" +"lua local mr=require('mason-registry'); mr.refresh(function() local pkg=mr.get_package('ruff'); if not pkg:is_installed() then pkg:install():once('closed', function() vim.cmd('qa') end) else print('ruff already installed'); vim.cmd('qa') end end)" (failed: Cannot find package "ruff"; subsequent install attempt hung)

------
https://chatgpt.com/codex/tasks/task_e_68a3541ddb58832c9d31a6def9a85dc9